### PR TITLE
fix: explicit type cast for Xcode 11 compatibility

### DIFF
--- a/RxAnimated.podspec
+++ b/RxAnimated.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RxAnimated'
-  s.version          = '0.6.0'
+  s.version          = '0.6.1'
   s.summary          = 'Animated bindings for RxSwift/RxCocoa'
 
   s.description      = <<-DESC

--- a/RxAnimated/Core/RxAnimated+bindings.swift
+++ b/RxAnimated/Core/RxAnimated+bindings.swift
@@ -36,14 +36,14 @@ extension AnimatedSink where Base: UILabel {
     public var text: Binder<String> {
         return Binder(self.base) { label, text in
             self.type.animate(view: label) {
-                label.text = text
+                (label as UILabel).text = text
             }
         }
     }
     public var attributedText: Binder<NSAttributedString> {
         return Binder(self.base) { label, text in
             self.type.animate(view: label) {
-                label.attributedText = text
+                (label as UILabel).attributedText = text
             }
         }
     }
@@ -54,14 +54,14 @@ extension AnimatedSink where Base: UIControl {
     public var isEnabled: Binder<Bool> {
         return Binder(self.base) { control, enabled in
             self.type.animate(view: control) {
-                control.isEnabled = enabled
+                (control as UIControl).isEnabled = enabled
             }
         }
     }
     public var isSelected: Binder<Bool> {
         return Binder(self.base) { control, selected in
             self.type.animate(view: control) {
-                control.isSelected = selected
+                (control as UIControl).isSelected = selected
             }
         }
     }
@@ -72,21 +72,21 @@ extension AnimatedSink where Base: UIButton {
     public var title: Binder<String> {
         return Binder(self.base) { button, title in
             self.type.animate(view: button) {
-                button.setTitle(title, for: button.state)
+                (button as UIButton).setTitle(title, for: button.state)
             }
         }
     }
     public var image: Binder<UIImage?> {
         return Binder(self.base) { button, image in
             self.type.animate(view: button) {
-                button.setImage(image, for: button.state)
+                (button as UIButton).setImage(image, for: button.state)
             }
         }
     }
     public var backgroundImage: Binder<UIImage?> {
         return Binder(self.base) { button, image in
             self.type.animate(view: button) {
-                button.setBackgroundImage(image, for: button.state)
+                (button as UIButton).setBackgroundImage(image, for: button.state)
             }
         }
     }
@@ -97,7 +97,7 @@ extension AnimatedSink where Base: UIImageView {
     public var image: Binder<UIImage?> {
         return Binder(self.base) { imageView, image in
             self.type.animate(view: imageView) {
-                imageView.image = image
+                (imageView as UIImageView).image = image
             }
         }
     }


### PR DESCRIPTION
Xcode 11 won't compile unless we cast explicitly the views in closure.