### PR TITLE
Fix animation of isHidden property on fading view out

### DIFF
--- a/RxAnimated/Core/RxAnimated.swift
+++ b/RxAnimated/Core/RxAnimated.swift
@@ -75,7 +75,7 @@ public struct AnimationType<Base> {
                     self.animations?(view)
                 }, completion: self.completion)
             case .transition(let type):
-                UIView.transition(with: view, duration: self.duration, options: self.options.union(type), animations: {
+                UIView.transition(with: view.superview!, duration: self.duration, options: self.options.union(type), animations: {
                     binding?()
                     self.animations?(view)
                 }, completion: self.completion)


### PR DESCRIPTION
Fade out doesn't animate when the `isHidden` property is set to `true`.