### PR TITLE
Fix swift build

### DIFF
--- a/Sources/RxAnimated/RxAnimated+animations.swift
+++ b/Sources/RxAnimated/RxAnimated+animations.swift
@@ -1,3 +1,5 @@
+#if canImport(UIKit)
+
 import RxSwift
 import RxCocoa
 import UIKit
@@ -60,3 +62,4 @@ extension AnimatedSink where Base: NSLayoutConstraint {
     }
 }
 
+#endif

--- a/Sources/RxAnimated/RxAnimated+bindings.swift
+++ b/Sources/RxAnimated/RxAnimated+bindings.swift
@@ -1,3 +1,5 @@
+#if canImport(UIKit)
+
 import RxSwift
 import RxCocoa
 import UIKit
@@ -135,3 +137,5 @@ extension AnimatedSink where Base: NSLayoutConstraint {
         }
     }
 }
+
+#endif

--- a/Sources/RxAnimated/RxAnimated.swift
+++ b/Sources/RxAnimated/RxAnimated.swift
@@ -1,3 +1,5 @@
+#if canImport(UIKit)
+
 import RxSwift
 import RxCocoa
 import UIKit
@@ -136,3 +138,5 @@ public struct AnimatedSink<Base> {
         self.type = type
     }
 }
+
+#endif


### PR DESCRIPTION
Run `swift build` locally, will get the following error:

```
RxAnimated % swift build
RxAnimated/Sources/RxAnimated/RxAnimated+animations.swift:3:8: error: no such module 'UIKit'
import UIKit
       ^
```
I know the discussion [here](https://github.com/RxSwiftCommunity/RxAnimated/pull/38#discussion_r388505253), but it may have been needed at some point.
