### PR TITLE
Fix Xcode build error

### DIFF
--- a/RxAnimated.podspec
+++ b/RxAnimated.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |cs|
-    s.source_files = 'Sources/RxAnimated/**/*'
+    s.source_files = 'Sources/RxAnimated/**/*.swift'
   end
 
 #  s.subspec 'Animations' do |cs|

--- a/RxAnimated.xcodeproj/project.pbxproj
+++ b/RxAnimated.xcodeproj/project.pbxproj
@@ -91,11 +91,11 @@
 /* Begin PBXFileReference section */
 		1ED86A8323E52B0200845373 /* RxAnimated.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxAnimated.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1ED86A8623E52B0200845373 /* RxAnimated.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxAnimated.h; sourceTree = "<group>"; };
-		1ED86A8723E52B0200845373 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1EEBCBFA23E560D30034B6CF /* Rx.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Rx.xcodeproj; path = Carthage/Checkouts/RxSwift/Rx.xcodeproj; sourceTree = "<group>"; };
 		1EF378932441DD7E006BF7C9 /* RxAnimated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxAnimated.swift; sourceTree = "<group>"; };
 		1EF378942441DD7E006BF7C9 /* RxAnimated+bindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxAnimated+bindings.swift"; sourceTree = "<group>"; };
 		1EF378952441DD7E006BF7C9 /* RxAnimated+animations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxAnimated+animations.swift"; sourceTree = "<group>"; };
+		C5E3559F25A04AA700F3D7AA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,8 +164,8 @@
 		1EF378922441DD7E006BF7C9 /* RxAnimated */ = {
 			isa = PBXGroup;
 			children = (
+				C5E3559F25A04AA700F3D7AA /* Info.plist */,
 				1ED86A8623E52B0200845373 /* RxAnimated.h */,
-				1ED86A8723E52B0200845373 /* Info.plist */,
 				1EF378932441DD7E006BF7C9 /* RxAnimated.swift */,
 				1EF378942441DD7E006BF7C9 /* RxAnimated+bindings.swift */,
 				1EF378952441DD7E006BF7C9 /* RxAnimated+animations.swift */,

--- a/Sources/RxAnimated/Info.plist
+++ b/Sources/RxAnimated/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.8.1</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	</dict>
+</plist>


### PR DESCRIPTION
With the current settings, can build `Exmaple/RxAnimated.xcworkspace` after `pod install`, but `./RxAnimated.xcodeproj` cannot be built with Xcode because there is no Info.plist.

[This commit](https://github.com/RxSwiftCommunity/RxAnimated/commit/eb9fe8dbb022f6f75503ab5f5b2719fd692fd52c) removes `Info.plist` to build the Example, but it's a good idea not to include` Info.plist` in the `pod install` code.